### PR TITLE
Update package.json for babel version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "homepage": "https://github.com/apache-superset/build-config#README",
   "dependencies": {
     "@babel/cli": "^7.1.2",
-    "@babel/core": "^7.1.2",
+    "@babel/core": "7.6.4",
     "@babel/plugin-proposal-class-properties": "^7.2.1",
     "@babel/plugin-proposal-export-default-from": "^7.0.0",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",


### PR DESCRIPTION
This PR is to lock the version of babel to the previous release since the latest one has some issue. Note this is a temp solution.