### PR TITLE
Pin babel cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/apache-superset/build-config#README",
   "dependencies": {
-    "@babel/cli": "^7.7.0",
+    "@babel/cli": "7.7.0",
     "@babel/core": "^7.7.2",
     "@babel/plugin-proposal-class-properties": "^7.7.0",
     "@babel/plugin-proposal-export-default-from": "^7.5.2",


### PR DESCRIPTION
Pins the babel cli version to fix CI.

This is because babel started failing for arguments passed in that it wasn't expected and beemo passes these through automatically.

This should probably be replaced with nimbus in the future, but this fixes builds for superset-ui packages for now

to: @williaster